### PR TITLE
Implement local lote management dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,8 +28,8 @@ export default function App() {
           </nav>
           <div className="conteudo">
             <Routes>
-              <Route path="/dashboard" element={<Dashboard token={token} />} />
-              <Route path="/lotes" element={<Lotes token={token} />} />
+              <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="/lotes" element={<Lotes />} />
               <Route path="*" element={<Navigate to="/dashboard" />} />
             </Routes>
           </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,40 @@
 import React, { useEffect, useState } from 'react';
 
-export default function Dashboard({ token }) {
+export default function Dashboard() {
   const [dados, setDados] = useState({ gpd: 0, lotes: 0, lucro: 0 });
 
+  const calcular = () => {
+    const lotes = JSON.parse(localStorage.getItem('lotes') || '[]');
+    if (!lotes.length) {
+      setDados({ gpd: 0, lotes: 0, lucro: 0 });
+      return;
+    }
+
+    const gpdTotal = lotes.reduce((acc, l) => {
+      const dias =
+        (new Date(l.dataSaida) - new Date(l.dataEntrada)) / 86400000;
+      const ganho = parseFloat(l.pesoSaida || 0) -
+        parseFloat(l.pesoEntrada || 0);
+      return acc + (dias > 0 ? ganho / dias : 0);
+    }, 0);
+
+    const lucroTotal = lotes.reduce((acc, l) => {
+      const ganhoPeso = parseFloat(l.pesoSaida || 0) -
+        parseFloat(l.pesoEntrada || 0);
+      const receita = ganhoPeso * 5; // valor hipotético por kg
+      const custo = parseFloat(l.custoRacao || 0);
+      return acc + (receita - custo);
+    }, 0);
+
+    setDados({
+      gpd: (gpdTotal / lotes.length).toFixed(2),
+      lotes: lotes.length,
+      lucro: lucroTotal
+    });
+  };
+
   useEffect(() => {
-    // Simulação inicial — depois substituir por rota real
-    setDados({ gpd: 650, lotes: 3, lucro: 2750 });
+    calcular();
   }, []);
 
   return (

--- a/src/pages/Lotes.jsx
+++ b/src/pages/Lotes.jsx
@@ -1,49 +1,143 @@
 import React, { useEffect, useState } from 'react';
 
-export default function Lotes({ token }) {
+export default function Lotes() {
   const [lotes, setLotes] = useState([]);
-  const [nome, setNome] = useState("");
+  const [form, setForm] = useState({
+    nome: '',
+    dataEntrada: '',
+    pesoEntrada: '',
+    dataSaida: '',
+    pesoSaida: '',
+    consumoRacao: '',
+    pesosSemanais: '',
+    custoRacao: ''
+  });
 
-  const buscar = async () => {
-    const res = await fetch("https://suinocultura-backend.onrender.com/lotes", {
-      headers: { Authorization: "Bearer " + token }
-    });
-    const data = await res.json();
-    setLotes(data);
+  const carregar = () => {
+    const saved = localStorage.getItem('lotes');
+    if (saved) setLotes(JSON.parse(saved));
   };
 
-  const adicionar = async () => {
-    if (!nome) return;
-    await fetch("https://suinocultura-backend.onrender.com/lotes", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + token
-      },
-      body: JSON.stringify({ nome })
+  const salvar = novos => {
+    localStorage.setItem('lotes', JSON.stringify(novos));
+    setLotes(novos);
+  };
+
+  const adicionar = () => {
+    if (!form.nome) return;
+    const novo = {
+      ...form,
+      id: Date.now(),
+      pesosSemanais: form.pesosSemanais
+        ? form.pesosSemanais.split(',').map(p => Number(p.trim()))
+        : []
+    };
+    const novos = [...lotes, novo];
+    salvar(novos);
+    setForm({
+      nome: '',
+      dataEntrada: '',
+      pesoEntrada: '',
+      dataSaida: '',
+      pesoSaida: '',
+      consumoRacao: '',
+      pesosSemanais: '',
+      custoRacao: ''
     });
-    setNome("");
-    buscar();
   };
 
   useEffect(() => {
-    buscar();
+    carregar();
   }, []);
+
+  const calcularGPD = lote => {
+    const dias =
+      (new Date(lote.dataSaida) - new Date(lote.dataEntrada)) / 86400000;
+    const ganho = parseFloat(lote.pesoSaida || 0) -
+      parseFloat(lote.pesoEntrada || 0);
+    return dias > 0 ? (ganho / dias).toFixed(2) : '0';
+  };
 
   return (
     <div>
       <h2>🐖 Gerenciar Lotes</h2>
-      <input
-        placeholder="Nome do lote"
-        value={nome}
-        onChange={(e) => setNome(e.target.value)}
-      />
-      <button onClick={adicionar}>➕ Adicionar</button>
-      <ul>
-        {lotes.map((l, i) => (
-          <li key={i}>📦 {l.nome}</li>
-        ))}
-      </ul>
+      <div style={{ display: 'flex', flexDirection: 'column', maxWidth: '400px' }}>
+        <input
+          placeholder="Nome do lote"
+          value={form.nome}
+          onChange={e => setForm({ ...form, nome: e.target.value })}
+        />
+        <input
+          type="date"
+          placeholder="Data de entrada"
+          value={form.dataEntrada}
+          onChange={e => setForm({ ...form, dataEntrada: e.target.value })}
+        />
+        <input
+          type="number"
+          placeholder="Peso de entrada (kg)"
+          value={form.pesoEntrada}
+          onChange={e => setForm({ ...form, pesoEntrada: e.target.value })}
+        />
+        <input
+          type="date"
+          placeholder="Data de saída"
+          value={form.dataSaida}
+          onChange={e => setForm({ ...form, dataSaida: e.target.value })}
+        />
+        <input
+          type="number"
+          placeholder="Peso de saída (kg)"
+          value={form.pesoSaida}
+          onChange={e => setForm({ ...form, pesoSaida: e.target.value })}
+        />
+        <input
+          type="number"
+          placeholder="Consumo de ração (kg)"
+          value={form.consumoRacao}
+          onChange={e => setForm({ ...form, consumoRacao: e.target.value })}
+        />
+        <input
+          placeholder="Pesos semanais (separados por vírgula)"
+          value={form.pesosSemanais}
+          onChange={e => setForm({ ...form, pesosSemanais: e.target.value })}
+        />
+        <input
+          type="number"
+          placeholder="Custo da ração (R$)"
+          value={form.custoRacao}
+          onChange={e => setForm({ ...form, custoRacao: e.target.value })}
+        />
+        <button onClick={adicionar}>➕ Adicionar</button>
+      </div>
+      <table border="1" cellPadding="5" style={{ marginTop: '1rem', width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Entrada</th>
+            <th>Peso Entrada</th>
+            <th>Saída</th>
+            <th>Peso Saída</th>
+            <th>Consumo (kg)</th>
+            <th>Custo (R$)</th>
+            <th>GPD (kg/dia)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lotes.map(l => (
+            <tr key={l.id}>
+              <td>{l.nome}</td>
+              <td>{l.dataEntrada}</td>
+              <td>{l.pesoEntrada}</td>
+              <td>{l.dataSaida}</td>
+              <td>{l.pesoSaida}</td>
+              <td>{l.consumoRacao}</td>
+              <td>{l.custoRacao}</td>
+              <td>{calcularGPD(l)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,3 +32,13 @@ body {
   margin: 1rem 0;
   width: 250px;
 }
+
+table {
+  background: white;
+  width: 100%;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 0.5rem;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- store batches in `localStorage`
- add extended lote form and table
- compute metrics from localStorage on dashboard
- tweak routing after removing token props
- style tables
- ignore node modules

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a8d104934832d978a9e289345fb95